### PR TITLE
Cargo: Remove target key for web-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,6 @@ js-sys = { version = "0.3" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
 version = "0.3"
-target = "wasm32"
 features = [
   'Headers',
   'Request',


### PR DESCRIPTION
Fix:
```
error: failed to parse manifest at `Cargo.toml`

Caused by:
  'target' specifier cannot be used without an 'artifact = …' value (web-sys)
```